### PR TITLE
ASM-3105 If IOA is configured in BMP mode ASM cannot configure it

### DIFF
--- a/lib/puppet/provider/force10_firmwareupdate/dell_ftos.rb
+++ b/lib/puppet/provider/force10_firmwareupdate/dell_ftos.rb
@@ -19,8 +19,23 @@ Puppet::Type.type(:force10_firmwareupdate).provide :dell_ftos, :parent => Puppet
     FileUtils.chmod_R 0755, tftp_dir
   end
 
+  def disable_bmp_mode
+    dev = Puppet::Util::NetworkDevice.current
+    dev.transport.command('enable')
+    reload_type = dev.transport.command('show reload-type').scan(/Next boot\s*:\s*(\S+)/).flatten.first
+    Puppet.debug("Reload Type: #{reload_type}")
+    if !reload_type.match(/normal-reload/)
+      Puppet.debug("Reload type is not 'normal-reload', updated the reload-type of the switch")
+      dev.transport.command('conf')
+      dev.transport.command('reload-type normal-reload')
+      dev.transport.command('end')
+      dev.transport.command('write memory')
+    end
+  end
+
   def run(url, force, copy_to_tftp=nil, path=nil)
     Puppet.debug("Puppet::Force10_firmwareUpdate*********************")
+    disable_bmp_mode
     if copy_to_tftp 
       move_to_tftp(copy_to_tftp,path)
     end


### PR DESCRIPTION
Updated the reload-type to normal-reload to ensure that the switch is not in BMP mode after reload