### PR TITLE
ASM-3106 ASM uplink configuration fails if IOA ports are configured in FC mode

### DIFF
--- a/lib/puppet/util/network_device/dell_ftos/possible_facts/hardware/m_series.rb
+++ b/lib/puppet/util/network_device/dell_ftos/possible_facts/hardware/m_series.rb
@@ -283,5 +283,12 @@ module Puppet::Util::NetworkDevice::Dell_ftos::PossibleFacts::Hardware::M_series
       cmd CMD_RUNNING_CONFIG
     end
 
+    base.register_param 'ioa_ethernet_mode' do
+      match do |txt|
+        txt = (txt.scan(/(stack-unit 0 port-group 0 portmode ethernet)/) || []).flatten.first
+      end
+      cmd CMD_RUNNING_CONFIG
+    end
+
   end
 end


### PR DESCRIPTION
Updated the facts table to capture the ethernet mode information of the IOA. This will be used for changing the switch to non-ethernet mode for IOA in PMUX mode