### PR TITLE
ASM-3361 Firmware update fails on IOAs

### DIFF
--- a/lib/puppet/provider/force10_firmwareupdate/dell_ftos.rb
+++ b/lib/puppet/provider/force10_firmwareupdate/dell_ftos.rb
@@ -21,6 +21,10 @@ Puppet::Type.type(:force10_firmwareupdate).provide :dell_ftos, :parent => Puppet
 
   def disable_bmp_mode
     dev = Puppet::Util::NetworkDevice.current
+    # Need to skip disable BMP mode configuration for IO Aggregators and FNIOA
+    switch_model = ( dev.switch.facts['product_name'] || '' )
+    return true if switch_model.match(/IOA|Aggregator/i)
+
     dev.transport.command('enable')
     reload_type = dev.transport.command('show reload-type').scan(/Next boot\s*:\s*(\S+)/).flatten.first
     Puppet.debug("Reload Type: #{reload_type}")


### PR DESCRIPTION
show reload-type command is not supported on IOAs which is used for disabling BMP mode on the switches. Added a skip check for IO Aggregator and SNIOA.