### PR TITLE
ASM-3475 Rack server switch configuration failed

### DIFF
--- a/lib/puppet/util/network_device/dell_ftos/possible_facts/base.rb
+++ b/lib/puppet/util/network_device/dell_ftos/possible_facts/base.rb
@@ -202,7 +202,7 @@ module Puppet::Util::NetworkDevice::Dell_ftos::PossibleFacts::Base
     
 
     base.register_module_after 'system_type', 's_series', 'hardware' do
-      base.facts['system_type'].value =~ /S4810/i ||  base.facts['system_type'].value =~ /S5000/i ||  base.facts['system_type'].value =~ /S6000/i
+      base.facts['system_type'].value =~ /S48*/i ||  base.facts['system_type'].value =~ /S5000/i ||  base.facts['system_type'].value =~ /S6000/i
     end
 
     base.register_module_after 'system_type', 'm_series', 'hardware' do


### PR DESCRIPTION
Discovery for S4820T switch is not capturing the facts which are required for ASM ToR configuration. Updated the regular expression to support all S48xx switches considering them same as S4810