### PR TITLE
Zone and zoneset need to be ensurable to work correctly

### DIFF
--- a/lib/puppet/provider/dell_ftos.rb
+++ b/lib/puppet/provider/dell_ftos.rb
@@ -20,11 +20,11 @@ class Puppet::Provider::Dell_ftos < Puppet::Provider::NetworkDevice
     resources.each do |name, resource|
       result = get_current(name)
       #We want to pass the transport through so we don't keep initializing new ssh connections for every single resource
-      result[:transport] = transport
       if result
+        result[:transport] = transport
         resource.provider = new(result)
       else
-        resource.provider = new(:ensure => :absent)
+        resource.provider = new(:ensure => :absent, :transport => transport)
       end
     end
   end

--- a/lib/puppet/type/force10_zone.rb
+++ b/lib/puppet/type/force10_zone.rb
@@ -5,6 +5,8 @@
 Puppet::Type.newtype(:force10_zone) do
   @doc = "This represents Dell Force10 zone configuration."
 
+  ensurable
+
   newparam(:name) do
     desc "This parameter describes the zone name to be created on the Force10 switch.
           The valid zone name does not allow blank value, special character except _ ,numeric char at the start, and length above 64 chars"

--- a/lib/puppet/type/force10_zoneset.rb
+++ b/lib/puppet/type/force10_zoneset.rb
@@ -5,6 +5,8 @@
 Puppet::Type.newtype(:force10_zoneset) do
   @doc = "This represents Dell Force10 zoneset configuration."
 
+  ensurable
+
   newparam(:name) do
     desc "This parameter describes the zoneset name to be created on the Force10 switch.
           The valid zoneset name does not allow blank value, special character except _ ,numeric char at the start, and length above 64 chars"

--- a/lib/puppet_x/force10/model/zone/base.rb
+++ b/lib/puppet_x/force10/model/zone/base.rb
@@ -22,15 +22,6 @@ module PuppetX::Force10::Model::Zone::Base
     end
 
     base.register_scoped :zonemember, zonemember_scope do
-#      match do |txt|
-#        paramsarray=txt.match(/^\s+ (\d+)/)
-#        if paramsarray.nil?
-#          param1 = :absent
-#        else
-#          param1 = paramsarray[1]
-#        end
-#      end
-      param = ":absent"
       cmd "show fc zone #{zonenameval}"
       default :absent
       add do |transport, value|


### PR DESCRIPTION
During refactoring to use Puppet apply, I had changed the providers to extend Puppet::Provider, and leaving the types as ensurable caused issues.  Later on, the providers were changed to use Puppet::Provider::NetworkDevice, which predefine the methods that ensurable needed that caused it to fail on Puppet::Provider.  ensurable provides some methods that zone/zoneset rely on to be setup correctly.

In particular, one of the methods that is invoked for ensure => :present is the one that correctly sets the properties that we want to set and without that, the properties were not updating correctly.

I'm not sure why this doesn't seem to cause issues with other providers which seem to be working fine, but this is something to keep in mind if we see similar issues.