### PR TITLE
ASM-5116 remote_device_info fact as list

### DIFF
--- a/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
@@ -306,19 +306,19 @@ module PuppetX::Force10::PossibleFacts::Hardware::M_series
     end
 
     base.register_param 'remote_device_info' do
-      remote_device_info = {}
+      remote_device_info = []
       remote_device = nil
       match do |txt|
         txt.each_line do |line|
           case line
             when /^\s+(\S+\s+\d+\/\d+)\s+(\S+)\s+(.*)\s+(([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2})).*$/
               remote_device = { :interface => $1.strip, :location => $3.strip,:remote_mac => $4.strip,:remote_system_name => $2.strip}
-              remote_device_info[remote_device[:interface]] = remote_device
+              remote_device_info <<  remote_device
             else
               next
           end
         end
-        remote_device_info.to_json
+        remote_device_info.uniq.to_json
       end
       cmd CMD_SHOW_LLDP_NEIGHBORS
     end

--- a/lib/puppet_x/force10/possible_facts/hardware/s_series.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/s_series.rb
@@ -216,7 +216,7 @@ module PuppetX::Force10::PossibleFacts::Hardware::S_series
 
     #Display LLDP neighbor information for all interfaces in JSON Format
     base.register_param 'remote_device_info' do
-      remote_device_info = {}
+      remote_device_info = []
       remote_device = nil
       match do |txt|
         txt.each_line do |line|
@@ -226,12 +226,12 @@ module PuppetX::Force10::PossibleFacts::Hardware::S_series
             #remote_device = { :local_interface => $1.strip, :local_port_id => "", :remote_port_id => $3.strip,:remote_mac_address => $4.strip,:remote_system_name => $2.strip}
             #remote_device_info[remote_device[:local_interface]] = remote_device
             remote_device = { :interface => $1.strip, :location => $3.strip,:remote_mac => $4.strip,:remote_system_name => $2.strip}
-            remote_device_info[remote_device[:interface]] = remote_device
+            remote_device_info << remote_device
           else
             next
           end
         end
-        remote_device_info.to_json
+        remote_device_info.uniq.to_json
       end
       cmd CMD_SHOW_LLDP_NEIGHBORS
     end


### PR DESCRIPTION
Change this fact to be a list of hashes.
From:
` { “interface name” => { :interface, :location, :remote_mac } } `
To:
`[ {:interface, :location, :remote_mac } ]`

example output:  https://gist.github.com/logankimmel/e6f2e553a2be2e4b096e