### PR TITLE
ASM-5383-2 Vlan-information values as strings

### DIFF
--- a/lib/puppet_x/force10/possible_facts/base.rb
+++ b/lib/puppet_x/force10/possible_facts/base.rb
@@ -209,12 +209,12 @@ module PuppetX::Force10::PossibleFacts::Base
         interfaces.each do |interface_detail|
           interface_location = interface_detail.scan(/^interface Vlan\s+(\d+)/).flatten.first
           vlan_information[interface_location] ||= {}
-          vlan_information[interface_location]['tagged_tengigabit'] ||= {}
-          vlan_information[interface_location]['untagged_tengigabit'] ||= {}
-          vlan_information[interface_location]['tagged_fortygigabit'] ||= {}
-          vlan_information[interface_location]['untagged_fortygigabit'] ||= {}
-          vlan_information[interface_location]['tagged_portchannel'] ||= {}
-          vlan_information[interface_location]['untagged_portchannel'] ||= {}
+          vlan_information[interface_location]['tagged_tengigabit'] ||= ""
+          vlan_information[interface_location]['untagged_tengigabit'] ||= ""
+          vlan_information[interface_location]['tagged_fortygigabit'] ||= ""
+          vlan_information[interface_location]['untagged_fortygigabit'] ||= ""
+          vlan_information[interface_location]['tagged_portchannel'] ||= ""
+          vlan_information[interface_location]['untagged_portchannel'] ||= ""
 
           if interface_detail.match(/^\stagged\s+TenGigabitEthernet\s+(.*?)$/mi)
             vlan_information[interface_location]['tagged_tengigabit'] = $1

--- a/lib/puppet_x/force10/possible_facts/hardware/ioa.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/ioa.rb
@@ -61,7 +61,6 @@ module PuppetX::Force10::PossibleFacts::Hardware::Ioa
             vlan_set.each do |v|
               vlan_information[v.to_s] ||= self.vlan_data
               vlan_information[v.to_s]["#{mode}_#{i_type}"] << interface_location
-              vlan_information[v.to_s]["#{mode}_#{i_type}"].uniq!
             end
           end
         end
@@ -69,8 +68,19 @@ module PuppetX::Force10::PossibleFacts::Hardware::Ioa
           (1..4095).each do |v|
             vlan_information[v.to_s] ||= self.vlan_data
             vlan_information[v.to_s]["tagged_#{i_type}"] << interface_location
-            vlan_information[v.to_s]["tagged_#{i_type}"].uniq!
           end
+        end
+      end
+      #Clean up data
+      vlan_information.each do |vlan, data|
+        data.each do |type, ports|
+          next unless ports
+          if ports.empty?
+            ports = ""
+          else
+            ports = ports.uniq.join(",") if ports.class == Array
+          end
+          data[type] = ports
         end
       end
     rescue => e

--- a/spec/unit/puppet_x/force10/possible_facts/hardware/ioa_spec.rb
+++ b/spec/unit/puppet_x/force10/possible_facts/hardware/ioa_spec.rb
@@ -10,19 +10,19 @@ describe PuppetX::Force10::PossibleFacts::Hardware::Ioa do
     it "should return the correct fact data" do
       vlan_info = ioa.vlan_information(sh_running_config)
       expect(vlan_info).to include("1")
-      expect(vlan_info["1"]).to eq({"tagged_tengigabit"=>["0/3", "0/5", "0/7", "0/8", "0/10", "0/11", "0/13", "0/16", "0/17", "0/18", "0/19", "0/21", "0/22", "0/23", "0/24", "0/25", "0/26", "0/27", "0/29", "0/30", "0/31", "0/32"],
-                                        "untagged_tengigabit"=>["0/6", "0/12", "0/14", "0/15", "0/28"],
-                                        "tagged_fortygigabit"=>[],
-                                        "untagged_fortygigabit"=>[],
-                                        "tagged_portchannel"=>[],
-                                        "untagged_portchannel"=>[]})
+      expect(vlan_info["1"]).to eq({"tagged_tengigabit"=>"0/3,0/5,0/7,0/8,0/10,0/11,0/13,0/16,0/17,0/18,0/19,0/21,0/22,0/23,0/24,0/25,0/26,0/27,0/29,0/30,0/31,0/32",
+                                        "untagged_tengigabit"=>"0/6,0/12,0/14,0/15,0/28",
+                                        "tagged_fortygigabit"=>"",
+                                        "untagged_fortygigabit"=>"",
+                                        "tagged_portchannel"=>"",
+                                        "untagged_portchannel"=>""})
       expect(vlan_info).to include("48")
-      expect(vlan_info["48"]).to eq({"tagged_tengigabit"=>["0/3", "0/5", "0/7", "0/8", "0/10", "0/11", "0/13", "0/16", "0/17", "0/18", "0/19", "0/21", "0/22", "0/23", "0/24", "0/25", "0/26", "0/27", "0/29", "0/30", "0/31", "0/32"],
-                                     "untagged_tengigabit"=>["0/4", "0/9"],
-                                     "tagged_fortygigabit"=>[],
-                                     "untagged_fortygigabit"=>[],
-                                     "tagged_portchannel"=>[],
-                                     "untagged_portchannel"=>[]})
+      expect(vlan_info["48"]).to eq({"tagged_tengigabit"=>"0/3,0/5,0/7,0/8,0/10,0/11,0/13,0/16,0/17,0/18,0/19,0/21,0/22,0/23,0/24,0/25,0/26,0/27,0/29,0/30,0/31,0/32",
+                                     "untagged_tengigabit"=>"0/4,0/9",
+                                     "tagged_fortygigabit"=>"",
+                                     "untagged_fortygigabit"=>"",
+                                     "tagged_portchannel"=>"",
+                                     "untagged_portchannel"=>""})
     end
   end
 end


### PR DESCRIPTION
The values need to be strings and not arrays in order to be consistant
with the other modules