### PR TITLE
ASM-5687 Checking for untagged VLAN's fails with list

### DIFF
--- a/spec/unit/puppet_x/force10/model/scoped_value_spec.rb
+++ b/spec/unit/puppet_x/force10/model/scoped_value_spec.rb
@@ -1,0 +1,27 @@
+require 'puppet_x/force10/model/scoped_value'
+
+describe PuppetX::Force10::Model::ScopedValue do
+  let(:sv) { PuppetX::Force10::Model::ScopedValue.new("name", double("transport"), double("facts"), nil) }
+
+  describe "#parse_interface_value" do
+    it "should return list of 3 interfaces" do
+      interface_value = "0/1,3,5"
+      expect(sv.parse_interface_value(interface_value)).to eq(["0/1","0/3","0/5"])
+    end
+
+    it "should return list of 1 interfaces" do
+      interface_value = "0/1"
+      expect(sv.parse_interface_value(interface_value)).to eq(["0/1"])
+    end
+
+    it "should return list of 2 interfaces" do
+      interface_value = "0/1,1/2"
+      expect(sv.parse_interface_value(interface_value)).to eq(["0/1","1/2"])
+    end
+
+    it "should return correct list when various stacks" do
+      interface_value = "1,2,1/3,2/3"
+      expect(sv.parse_interface_value(interface_value)).to eq(["0/1","0/2","1/3","2/3"])
+    end
+  end
+end


### PR DESCRIPTION
When a list is supplied as the value for the "untagged_vlan" param
in the `mxl_vlan` resource, we need to loop through these when checking
for other untagged vlans for this resource