### PR TITLE
Quad Port command confirmation required with FTOS 9.8

### DIFF
--- a/lib/puppet_x/force10/model/quadmode.rb
+++ b/lib/puppet_x/force10/model/quadmode.rb
@@ -32,8 +32,9 @@ class PuppetX::Force10::Model::Quadmode < PuppetX::Force10::Model::Base
   def perform_update(is, should, reboot_required)
     interface_num = @name.scan(/(\d+)/).flatten.last
     if should[:ensure] == :present and is[:ensure] == :absent
-      out = transport.command("stack-unit 0 port #{interface_num} portmode quad")
-      elsif should[:ensure] == :absent and is[:ensure] == :present
+      transport.command("stack-unit 0 port #{interface_num} portmode quad")
+      transport.command("yes")
+    elsif should[:ensure] == :absent and is[:ensure] == :present
       # Ensure that we are on the normal prompt
       transport.command("end")
       transport.command("conf")


### PR DESCRIPTION
Added confirmation "yes" after enabling quad port command on the switch. this was missing in the existing flow