### PR TITLE
ASM-5909 quadport mode not working for MXL

### DIFF
--- a/lib/puppet_x/force10/model/quadmode.rb
+++ b/lib/puppet_x/force10/model/quadmode.rb
@@ -32,7 +32,7 @@ class PuppetX::Force10::Model::Quadmode < PuppetX::Force10::Model::Base
   def perform_update(is, should, reboot_required)
     interface_num = @name.scan(/(\d+)/).flatten.last
     if should[:ensure] == :present and is[:ensure] == :absent
-      transport.command("stack-unit 0 port #{interface_num} portmode quad")
+      transport.command("stack-unit 0 port #{interface_num} portmode quad", :prompt => /confirm.*|conf.*/)
       transport.command("yes")
     elsif should[:ensure] == :absent and is[:ensure] == :present
       # Ensure that we are on the normal prompt


### PR DESCRIPTION
For enabling / disabling quad mode on the interface, a confirmation prompt needs to be handled. Earlier PR was missing the intermediate prompt value.