### PR TITLE
ASM-6017 remove VLANs from opposing type if needed

### DIFF
--- a/spec/unit/puppet_x/force10/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface/base_spec.rb
@@ -2,19 +2,18 @@ require "spec_helper"
 require "puppet_x/force10/model/interface/base"
 
 describe PuppetX::Force10::Model::Interface::Base do
-  let (:base) { PuppetX::Force10::Model::Interface::Base }
+  let(:base) { PuppetX::Force10::Model::Interface::Base }
+  let(:transport) { stub("rspec-transport") }
 
   describe "#show_interface_vlans" do
     it "should parse only untagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/only_untagged.out")
-      transport = Object.new
       transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
       expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", []])
     end
 
     it "should parse untagged and tagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/tagged_and_untagged.out")
-      transport = Object.new
       transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
       expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["18", %w(16 20 23 28)])
     end
@@ -24,6 +23,93 @@ describe PuppetX::Force10::Model::Interface::Base do
       transport = Object.new
       transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
       expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", %w(18 19 20 21 28)])
+    end
+  end
+
+  describe "#update_vlans" do
+    let(:interface_type) { "Tengigabit" }
+    let(:interface_id) { "0/4" }
+    let(:interface_info) { [interface_type, interface_id] }
+
+    it "should add tagged vlans" do
+      expect(base).to receive(:show_interface_vlans)
+          .with(transport, interface_type, interface_id)
+          .and_return(["1", []])
+      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface vlan 28").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
+      base.update_vlans(transport, ["20", "28"], true, interface_info)
+    end
+
+    it "should add tagged vlans and unset extra tagged" do
+      expect(base).to receive(:show_interface_vlans)
+                          .with(transport, interface_type, interface_id)
+                          .and_return(["1", ["18"]])
+      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface vlan 28").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
+      base.update_vlans(transport, ["20", "28"], true, interface_info)
+    end
+
+    it "should add tagged vlans and unset any that are untagged" do
+      expect(base).to receive(:show_interface_vlans)
+                          .with(transport, interface_type, interface_id)
+                          .and_return(["20", []])
+      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface vlan 28").ordered
+      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
+      base.update_vlans(transport, ["20", "28"], true, interface_info)
+    end
+
+    it "should set untagged vlan" do
+      expect(base).to receive(:show_interface_vlans)
+                          .with(transport, interface_type, interface_id)
+                          .and_return(["1", []])
+      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 1").ordered
+      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
+      base.update_vlans(transport, ["18"], false, interface_info)
+    end
+
+    it "should set untagged vlan and remove from tagged if needed" do
+      expect(base).to receive(:show_interface_vlans)
+                          .with(transport, interface_type, interface_id)
+                          .and_return(["1", ["18"]])
+      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 1").ordered
+      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
+      base.update_vlans(transport, ["18"], false, interface_info)
     end
   end
 end


### PR DESCRIPTION
update_vlans wasn't removing VLANs from the opposing type causing
failures. For example, if you want to set VLAN 18 as untagged you need
to remove it as a tagged vlan if it exists there.