### PR TITLE
ASM-6055 Gather LLDP data for FN IOAs

### DIFF
--- a/lib/puppet_x/force10/possible_facts/base.rb
+++ b/lib/puppet_x/force10/possible_facts/base.rb
@@ -252,7 +252,9 @@ module PuppetX::Force10::PossibleFacts::Base
     end
 
     base.register_module_after 'system_type', 'm_series', 'hardware' do
-      base.facts['system_type'].value =~ /I\/O-Aggregator|IOA/i || base.facts['system_type'].value =~ /MXL/i
+      (base.facts['system_type'].value =~ /I\/O-Aggregator|IOA/i ||
+          base.facts['system_type'].value =~ /MXL/i ||
+          base.facts['system_type'].value =~ /PE-FN/i)
     end
 
     base.register_module_after 'vlan_information', 'ioa', 'hardware' do


### PR DESCRIPTION
FN IOAs which have a system types like "PE-FN-2210S-IOM" were not
recognized as M-series or S-series switches. Therefore some inventory
data like "show lldp neighbors" was not gathered. Add a system_type to
match them to the M-series switches, which hopefully they are pretty
similar to.