### PR TITLE
ASM-5133 treat empty vlan string as empty list

### DIFF
--- a/lib/puppet_x/force10/model/interface/base.rb
+++ b/lib/puppet_x/force10/model/interface/base.rb
@@ -306,12 +306,8 @@ module PuppetX::Force10::Model::Interface::Base
     vlans = []
     value = value.to_s
     values = []
-    if value.include? ","
-      value.split(",").each do |vlan_group|
-        values << vlan_group
-      end
-    else value
-      values << value
+    value.split(",").each do |vlan_group|
+      values << vlan_group
     end
     values.each do |vlan_group|
       if vlan_group.include? "-"

--- a/spec/unit/puppet_x/force10/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface/base_spec.rb
@@ -5,6 +5,24 @@ describe PuppetX::Force10::Model::Interface::Base do
   let(:base) { PuppetX::Force10::Model::Interface::Base }
   let(:transport) { stub("rspec-transport") }
 
+  describe "#vlans_from_list" do
+    it "should return a single vlan as a list" do
+      expect(base.vlans_from_list("20")).to eq(["20"])
+    end
+
+    it "should return empty string as an empty list" do
+      expect(base.vlans_from_list("")).to eq([])
+    end
+
+    it "should split comma-separated vlans" do
+      expect(base.vlans_from_list("20,21,22")).to eq(%w(20 21 22))
+    end
+
+    it "should handle ranges" do
+      expect(base.vlans_from_list("18,20-22,28")).to eq(%w(18 20 21 22 28))
+    end
+  end
+
   describe "#show_interface_vlans" do
     it "should parse only untagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/only_untagged.out")


### PR DESCRIPTION
Previously if an empty string was passed as tagged_vlan or
untagged_vlan for force10_interface the module would try to tag or
untag "" as the vlan rather than treating it as "no vlan". It still
had the intended behavior of removing other vlans and wouldn't fail
because this module currently pretty much eats all errors. That will
have to be fixed later...