### PR TITLE
ASM-6127 Uplink configuration for IOAs is missing port information

### DIFF
--- a/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
@@ -203,7 +203,7 @@ module PuppetX::Force10::PossibleFacts::Hardware::M_series
       module3_interface = []
       interface_info = {}
       match do |txt|
-        base.facts['product_name'].value.match(/IOA/) ? module1_interfaces = 9..12 : module1_interfaces = 33..40
+        base.facts['product_name'].value.match(/IOA|PE-FN|Dell PowerEdge FN/) ? module1_interfaces = 9..12 : module1_interfaces = 33..40
         txt.each_line do |line|
           case line
           when /^(\S+)\s+(\d+)\/(\d+)/m


### PR DESCRIPTION
FNIOA model information is updated with FTOS 9.9. Included new patterns to be search for identification of FNIOA to enable uplink configuration