### PR TITLE
ASM-6191: Do not fail on name errors

### DIFF
--- a/lib/puppet_x/force10/model/scoped_value.rb
+++ b/lib/puppet_x/force10/model/scoped_value.rb
@@ -61,9 +61,13 @@ class PuppetX::Force10::Model::ScopedValue < PuppetX::Force10::Model::GenericVal
   end
 
   def parseforerror(outtxt,placestr)
-    if outtxt =~/Error:\s*(.*)/
-      Puppet.info "ERROR:#{$1}"
-      raise "Unable to "+placestr+".Reason:#{$1}"
+    match = outtxt.match(/Error:\s*(?<error>.*)/)
+
+    if match
+      return if match[:error] =~ /Name already exists/
+
+      Puppet.info("ERROR:%s" % match[:error])
+      raise("Unable to %s.Reason:%s" % [placestr, match[:error]])
     end
   end
 

--- a/spec/unit/puppet_x/force10/model/scoped_value_spec.rb
+++ b/spec/unit/puppet_x/force10/model/scoped_value_spec.rb
@@ -3,6 +3,18 @@ require 'puppet_x/force10/model/scoped_value'
 describe PuppetX::Force10::Model::ScopedValue do
   let(:sv) { PuppetX::Force10::Model::ScopedValue.new("name", double("transport"), double("facts"), nil) }
 
+  describe "#parseforerror" do
+    it "should not raise on duplicate name errors" do
+      sv.parseforerror("Error: Name already exists.", "add the property value for the parameter 'name'")
+    end
+
+    it "should raise for other errors" do
+      expect {
+        sv.parseforerror("Error: rspec error.", "add the property value for the parameter 'name'")
+      }.to raise_error("Unable to add the property value for the parameter 'name'.Reason:rspec error.")
+    end
+  end
+
   describe "#parse_interface_value" do
     it "should return list of 3 interfaces" do
       interface_value = "0/1,3,5"


### PR DESCRIPTION
This happens when a VLAN called something already exist, skip these
errors in all cases