### PR TITLE
ASM 6252, 6774 - updated to configure spanning-tree edge-port protocol

### DIFF
--- a/lib/puppet/type/force10_interface.rb
+++ b/lib/puppet/type/force10_interface.rb
@@ -68,7 +68,9 @@ Puppet::Type.newtype(:force10_interface) do
 
   newproperty(:edge_port) do
     desc "property to set the spanning-tree edge-port setting"
-    newvalues('edge-port')
+    validate do |value|
+      return if value.empty?
+    end
   end
 
   newproperty(:protocol) do

--- a/spec/fixtures/show_interfaces_switchport/show_switch_no_spt.out
+++ b/spec/fixtures/show_interfaces_switchport/show_switch_no_spt.out
@@ -1,0 +1,10 @@
+!
+interface TenGigabitEthernet 0/14
+ no ip address
+ mtu 12000
+ portmode hybrid
+ switchport
+ spanning-tree 0 portfast
+!
+ protocol lldp
+ no shutdown

--- a/spec/fixtures/show_interfaces_switchport/show_switch_spt.out
+++ b/spec/fixtures/show_interfaces_switchport/show_switch_spt.out
@@ -1,0 +1,13 @@
+!
+interface TenGigabitEthernet 0/14
+ no ip address
+ mtu 12000
+ portmode hybrid
+ switchport
+ spanning-tree mstp edge-port
+ spanning-tree rstp edge-port
+ spanning-tree 0 portfast
+ spanning-tree pvst edge-port
+!
+ protocol lldp
+ no shutdown

--- a/spec/unit/puppet_x/force10/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface/base_spec.rb
@@ -130,4 +130,54 @@ describe PuppetX::Force10::Model::Interface::Base do
       base.update_vlans(transport, ["18"], false, interface_info)
     end
   end
+
+  describe "#show_stp_val" do
+    let(:interface_type) { "Te 0/14" }
+    it "should parse only existing spanning-tree protcol edge-port"do
+      out = PuppetSpec.load_fixture("show_interfaces_switchport/show_switch_spt.out")
+      transport.stub(:command).with("show config").and_return(out)
+      expect(base.show_stp_val(transport,"Te 0/14")).to eq(["mstp","rstp","pvst"])
+    end
+    it "should parse no spanning-tree edge-port"do
+      out = PuppetSpec.load_fixture("show_interfaces_switchport/show_switch_no_spt.out")
+      transport.stub(:command).with("show config").and_return(out)
+      expect(base.show_stp_val(transport,"Te 0/14")).to eq([])
+    end
+  end
+
+  describe "#update_stp"do
+    it "should add valid spanning-tree protocol type"do
+     expect(transport).to receive(:command).with("config").ordered
+     expect(transport).to receive(:command).with("interface Te 0/14").ordered
+     expect(transport).to receive(:command).with("spanning-tree mvst edge-port").ordered
+     expect(transport).to receive(:command).with("config").ordered
+     expect(transport).to receive(:command).with("interface Te 0/14").ordered
+     expect(transport).to receive(:command).with("spanning-tree rstp edge-port").ordered
+     base.update_stp(transport,"Te 0/14",["pvst"],["mvst","rstp","pvst"])
+    end
+
+    it "should add correct spanning-tree protocol type"do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("no spanning-tree mvst edge-port").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("no spanning-tree rstp edge-port").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
+      base.update_stp(transport,"Te 0/14", ["mvst","rstp"],["pvst"])
+    end
+
+     it "should add parsed spanning-tree protocol type"do
+       expect(transport).to receive(:command).with("config").ordered
+       expect(transport).to receive(:command).with("interface Te 0/14").ordered
+       expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
+       base.update_stp(transport,"Te 0/14", [],["pvst"])
+     end
+ end
 end
+
+
+
+

--- a/spec/unit/puppet_x/force10/model/interface_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface_spec.rb
@@ -107,8 +107,11 @@ describe PuppetX::Force10::Model::Interface do
       interface.retrieve
       old_params = interface.params_to_hash
       new_params = old_params.dup
-      new_params[:edge_port] = 'edge-port'
-      @transport.should_receive(:command).with('spanning-tree pvst edge-port')
+      new_params[:edge_port] = 'pvst'
+      @transport.should_receive(:command).with("show config")
+      @transport.should_receive(:command).with("config")
+      @transport.should_receive(:command).with("interface TenGigabitEthernet 0/7")
+      @transport.should_receive(:command).with("spanning-tree pvst edge-port")
       interface.update(old_params, new_params)
     end
   end


### PR DESCRIPTION
ASM will configure spanning-tree edge port to pvst alone. If user want to configure other edge port like MSTP, RSTP  then ASM will fail in configuring. 

Below changes will fix this issue. 