### PR TITLE
ASM-6083 dependency updated invalid commands on force10 puppet model

### DIFF
--- a/lib/puppet_x/force10/fact.rb
+++ b/lib/puppet_x/force10/fact.rb
@@ -14,6 +14,10 @@ class PuppetX::Force10::Fact
   define_value_method [:cmd, :match, :add, :remove, :before, :after, :match_param, :required]
 
   def parse(txt)
+    if !txt.nil?
+      raise(ArgumentError, "Invalid Command:\t #{cmd} while loading facts") if txt =~ /\sError: ((Invalid input)|(Incomplete command))\s/
+    end
+
     if self.match.is_a?(Proc)
       self.value = self.match.call(txt)
     else

--- a/lib/puppet_x/force10/model/interface/base.rb
+++ b/lib/puppet_x/force10/model/interface/base.rb
@@ -8,11 +8,11 @@ module PuppetX::Force10::Model::Interface::Base
       cmd 'sh run'
       match /^\s*#{base_command}\s+(.*?)\s*$/
       add do |transport, value|
-        Puppet.debug(" command #{base_command} value  #{value}" )
+        Puppet.debug(" command #{base_command} value  #{value}")
         transport.command("#{base_command} #{value}")
       end
       remove do |transport, old_value|
-        Puppet.debug(" No  command #{base_command} value  #{value}" )
+        Puppet.debug(" No  command #{base_command} value  #{value}")
         transport.command("no #{base_command} #{old_value}")
       end
       evaluate(&block) if block
@@ -31,8 +31,8 @@ module PuppetX::Force10::Model::Interface::Base
         end
       end
       default :absent
-      add { |*_| }
-      remove { |*_| }
+      add { |*_|}
+      remove { |*_|}
     end
 
     ifprop(base, :portchannel) do
@@ -79,7 +79,7 @@ module PuppetX::Force10::Model::Interface::Base
           transport.command("no shutdown")
         end
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :mtu) do
@@ -87,7 +87,7 @@ module PuppetX::Force10::Model::Interface::Base
       add do |transport, value|
         transport.command("mtu #{value}")
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :switchport) do
@@ -103,7 +103,7 @@ module PuppetX::Force10::Model::Interface::Base
       end
       add do |transport, value|
         if value == :true
-          transport.command("switchport")do |out|
+          transport.command("switchport") do |out|
             if out =~/Error:\s*(.*)/
               Puppet.debug "#{$1}"
             end
@@ -118,7 +118,7 @@ module PuppetX::Force10::Model::Interface::Base
         end
 
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :dcb_map) do
@@ -135,7 +135,7 @@ module PuppetX::Force10::Model::Interface::Base
         # Command to associate DCB map with the interface
         transport.command("dcb-map #{value}")
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :fcoe_map) do
@@ -143,7 +143,7 @@ module PuppetX::Force10::Model::Interface::Base
       add do |transport, value|
         transport.command("fcoe-map #{value}")
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :fabric) do
@@ -151,7 +151,7 @@ module PuppetX::Force10::Model::Interface::Base
       add do |transport, value|
         transport.command("fabric #{value}")
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :portmode) do
@@ -169,7 +169,7 @@ module PuppetX::Force10::Model::Interface::Base
           transport.command("#{remove_command}")
         end
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :portfast) do
@@ -177,7 +177,7 @@ module PuppetX::Force10::Model::Interface::Base
       add do |transport, value|
         transport.command("spanning-tree 0 #{value}")
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :edge_port) do
@@ -187,7 +187,7 @@ module PuppetX::Force10::Model::Interface::Base
         stp_val = PuppetX::Force10::Model::Interface::Base.show_stp_val(transport, scope_name)
         PuppetX::Force10::Model::Interface::Base.update_stp(transport, scope_name, stp_val, value)
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :protocol) do
@@ -206,17 +206,14 @@ module PuppetX::Force10::Model::Interface::Base
       empty_match=''
       match do |empty_match|
         unless empty_match.nil?
-          :false  #This is so we always go through the "add" swimlane
+          :false #This is so we always go through the "add" swimlane
         end
       end
       add do |transport, value|
-        existing_config = transport.command('show config') || ''
-        iface = existing_config.match(/\s*interface\s+(.*?)\s*$/)[1]
-        type, interface_id = PuppetX::Force10::Model::Interface::Base.parse_interface(iface)
-        vlans = PuppetX::Force10::Model::Interface::Base.vlans_from_list(value)
-        PuppetX::Force10::Model::Interface::Base.update_vlans(transport, vlans, false, [type, interface_id])
+        untagged, tagged = PuppetX::Force10::Model::Interface::Base.show_interface_vlans(transport, scope_name)
+        PuppetX::Force10::Model::Interface::Base.update_untagged_vlans(transport, value, untagged, scope_name)
       end
-      remove { |*_| }
+      remove { |*_|}
     end
 
     ifprop(base, :tagged_vlan) do
@@ -227,112 +224,100 @@ module PuppetX::Force10::Model::Interface::Base
         end
       end
       add do |transport, value|
-        existing_config = transport.command('show config') || ''
-        iface = existing_config.match(/\s*interface\s+(.*?)\s*$/)[1]
-        type, interface_id = PuppetX::Force10::Model::Interface::Base.parse_interface(iface)
-        vlans = PuppetX::Force10::Model::Interface::Base.vlans_from_list(value)
-        PuppetX::Force10::Model::Interface::Base.update_vlans(transport, vlans, true, [type, interface_id])
+        untagged, tagged = PuppetX::Force10::Model::Interface::Base.show_interface_vlans(transport, scope_name)
+        PuppetX::Force10::Model::Interface::Base.update_tagged_vlans(transport, value, tagged, scope_name)
       end
-      remove { |*_| }
+      remove { |*_|}
     end
   end
 
   # Return the untagged and tagged vlans associated with the switch port as a tuple
   #
   # @param transport [PuppetX::Force10::Transport::Ssh] the switch ssh transport
-  # @param interface_type [String] the interface type e.g. Tengigabitethernet
-  # @param interface_id [String] the interface port, e.g. 0/4
+  # @param interface_info [String] the interface id e.g. Tengigabitethernet 0/14
   # @return [Array] tuple of untagged vlan and list of tagged vlans
-  def self.show_interface_vlans(transport, interface_type, interface_id)
+  def self.show_interface_vlans(transport, interface_info)
     untagged_vlan = nil
     tagged_vlans = []
-    current_vlan_info = transport.command("show interfaces switchport #{interface_type} #{interface_id}")
-    current_vlan_info.each_line do |line|
-      if line =~ /^U\s+(\d+)$/
-        untagged_vlan = $1
-      elsif line =~ /^T\s+([0-9,-]+)$/
-        tagged_vlans = vlans_from_list($1)
+    transport.command("exit") # Bring us back to config state
+    transport.command("exit") # Bring us back to main
+
+    current_vlan_info = transport.command("show interfaces switchport #{interface_info}")
+    current_vlan_info.match /^U\s+([\d]+)$/
+    if $1.nil? || $1.empty?
+      untagged_vlan = []
+    else
+      untagged_vlan = [$1.to_i]
+    end
+    vlan_info = current_vlan_info.match /^T\s+([\d\-,]+)$/
+    str = vlan_info.nil? ? "" : vlan_info[1]
+    str_arr = str.split(",")
+    str_arr.each do |num_str|
+      num = num_str.to_i
+      if num_str == num.to_s
+        tagged_vlans << num
+      else
+        nums = num_str.split("-").map(&:to_i)
+        nums[0].upto(nums[1]).each do |range_num|
+          tagged_vlans << range_num
+        end
       end
     end
-    [untagged_vlan, tagged_vlans]
+    return [untagged_vlan, tagged_vlans]
   end
 
-  def self.update_vlans(transport, new_vlans, tagged, interface_info)
-    vlan_type = tagged ? "tagged" : "untagged"
-    opposite_vlan_type = tagged ? "untagged" : "tagged"
-    interface_type, interface_id = interface_info
+  def self.update_untagged_vlans(transport, value, existing_vlan, interface_id)
+    raise(ArgumentError, "Too many untagged vlans on port %s: %s" %[interface_id, existing_vlan.join(",")]) if existing_vlan.size > 1
 
-    transport.command("exit") # bring us back to config
-    transport.command("exit") # bring us back to main
+    value = value.split(",").map(&:to_i)
+    raise(ArgumentError, "Too many untagged vlans requested %s" %value) if existing_vlan.size > 1
 
-    curr_untagged_vlan, curr_tagged_vlans = show_interface_vlans(transport, interface_type, interface_id)
-    if tagged
-      current_vlans = curr_tagged_vlans
-      opposite_vlans_to_remove = new_vlans & [curr_untagged_vlan].compact
-    else
-      current_vlans = [curr_untagged_vlan].compact
-      opposite_vlans_to_remove = new_vlans & curr_tagged_vlans
-    end
     transport.command("config")
 
-    # Remove VLANs from the opposing VLAN type
-    opposite_vlans_to_remove.each do |vlan|
-      Puppet.debug("Removing opposing vlan #{vlan} from interface #{interface_id}")
-      transport.command("interface vlan #{vlan}")
-      transport.command("no #{opposite_vlan_type} #{interface_type} #{interface_id}")
-      transport.command("exit")
-    end
-
-    # Remove all the unused vlans
-    vlans_to_remove = current_vlans - new_vlans
+    vlans_to_remove = existing_vlan - value
     vlans_to_remove.each do |vlan|
-      Puppet.debug("Removing vlan #{vlan} from interface #{interface_id}")
+      next if vlan == 1
+      Puppet.debug("removing vlan #{vlan} from interface : #{interface_id}")
       transport.command("interface vlan #{vlan}")
-      transport.command("no #{vlan_type} #{interface_type} #{interface_id}")
+      transport.command("no untagged #{interface_id}")
       transport.command("exit")
     end
-    # Add the new vlans
-    vlans_to_add = new_vlans - current_vlans
+
+    vlans_to_add = value - existing_vlan
     vlans_to_add.each do |vlan|
-      Puppet.debug("Adding vlan #{vlan} to interface #{interface_id}")
+      next if vlan == 1
+      Puppet.debug("Adding vlan #{vlan} to interface: #{interface_id}")
       transport.command("interface vlan #{vlan}")
-      transport.command("#{vlan_type} #{interface_type} #{interface_id}")
+      transport.command("untagged #{interface_id}")
+      transport.command("exit")
     end
-    # Return transport back to beginning location
-    transport.command("interface #{interface_type} #{interface_id}")
+    transport.command("interface #{interface_id}") # Return transport back to configured interface state
   end
 
-  def self.parse_interface(iface)
-    if iface.include? 'TenGigabitEthernet'
-      iface.slice! 'TenGigabitEthernet '
-      type = 'TenGigabitEthernet'
-    elsif iface.include? 'FortyGigE'
-      iface.slice! 'FortyGigE '
-      type = 'fortyGigE'
-    else
-      raise Puppet::Error, "Unknown interface type #{iface}"
-    end
-    [type, iface]
-  end
+  def self.update_tagged_vlans(transport, value, existing_vlans, interface_id)
+    value = value.split(",").map(&:to_i)
 
-  def self.vlans_from_list(value)
-    vlans = []
-    value = value.to_s
-    values = []
-    value.split(",").each do |vlan_group|
-      values << vlan_group
+    transport.command("config")
+
+    vlans_to_remove = existing_vlans - value
+    vlans_to_remove.each do |vlan|
+      Puppet.debug("Removing vlan #{vlan} tagged traffic from interface: #{interface_id}")
+      transport.command("interface vlan #{vlan}")
+      transport.command("no tagged #{interface_id}")
+      transport.command("exit")
     end
-    values.each do |vlan_group|
-      if vlan_group.include? "-"
-        first = vlan_group.split("-")[0]
-        last = vlan_group.split("-")[1]
-        vlans.concat((Integer(first)..Integer(last)).to_a.map(&:to_s))
-      else
-        vlans << vlan_group
-      end
+
+    vlans_to_add = value - existing_vlans
+    vlans_to_add.each do |vlan|
+      Puppet.debug("Adding vlan #{vlan} tagged traffic to interface: #{interface_id}")
+      transport.command("interface vlan #{vlan}")
+      transport.command("tagged #{interface_id}")
+      transport.command("exit")
     end
-    vlans.uniq!
-    vlans
+    transport.command("exit") #Bring us back to main state
+    transport.command("show interfaces switchport #{interface_id}")
+    transport.command("config") #Return configuration back to original state
+    transport.command("interface #{interface_id}")
   end
 
   def self.show_stp_val(transport, interface_id)
@@ -350,18 +335,20 @@ module PuppetX::Force10::Model::Interface::Base
 
   def self.update_stp(transport, interface_id, existing_stp_val, value)
     remove_stp = existing_stp_val - value
+    transport.command("exit") # Bring back to configure state
+
     remove_stp.each do |type|
-      transport.command("config")
       transport.command("interface #{interface_id}")
       transport.command("no spanning-tree #{type} edge-port")
+      transport.command("exit")
     end
 
     adding_stp = value - existing_stp_val
     adding_stp.each do |type|
-      transport.command("config")
       transport.command("interface #{interface_id}")
       transport.command("spanning-tree #{type} edge-port")
+      transport.command("exit")
     end
+    transport.command("interface #{interface_id}") # Return transport back to configured interface state
   end
 end
-

--- a/lib/puppet_x/force10/model/scoped_value.rb
+++ b/lib/puppet_x/force10/model/scoped_value.rb
@@ -47,6 +47,10 @@ class PuppetX::Force10::Model::ScopedValue < PuppetX::Force10::Model::GenericVal
   end
 
   def parse(txt)
+    if !txt.nil?
+      raise(ArgumentError, "Invalid Command:\t #{cmd} while evaluating scope from facts") if txt =~ /\sError: ((Invalid input)|(Incomplete command))\s/
+    end
+
     result = extract_scope(txt)
     if result.nil? || result.empty?
       Puppet.debug("Scope #{scope} not found for Param #{name}")

--- a/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
@@ -12,7 +12,7 @@ module PuppetX::Force10::PossibleFacts::Hardware::M_series
   CMD_SHOW_PORT_CHANNELS  ="show interfaces port-channel brief" unless const_defined?(:CMD_SHOW_PORT_CHANNELS)
   CMD_SHOW_QUAD_MODE_INTERFACES  ="show running-config | grep \"portmode quad\"" unless const_defined?(:CMD_SHOW_QUAD_MODE_INTERFACES)
   CMD_SHOW_RUNNING_INTERFACE ="show running-config interface" unless const_defined?(:CMD_SHOW_RUNNING_INTERFACE)
-  CMD_SHOW_SYSTEM_STACK_UNIT_IOM = 'show system stack-unit 0 iom-mode' unless const_defined?(:CMD_SHOW_SYSTEM_STACK_UNIT_IOM)
+  CMD_SHOW_SYSTEM_STACK_UNIT_IOM = 'show system stack-unit 0 | grep stack-unit' unless const_defined?(:CMD_SHOW_SYSTEM_STACK_UNIT_IOM)
   CMD_RUNNING_CONFIG = 'show running-config' unless const_defined?(:CMD_RUNNING_CONFIG)
   CMD_STACK_PORT_TOPOLOGY = 'show system stack-port topology' unless const_defined?(:CMD_STACK_PORT_TOPOLOGY)
   CMD_SHOW_LLDP_NEIGHBORS  ="show lldp neighbors" unless const_defined?(:CMD_SHOW_LLDP_NEIGHBORS)
@@ -247,7 +247,10 @@ module PuppetX::Force10::PossibleFacts::Hardware::M_series
     base.register_param 'iom_mode' do
       retval = []
       match do |txt|
-        item = (txt.scan(/^\d+\s+(\S+)/) || []).flatten.first
+        txt.split("\n").each do |line|
+          match_data = line.match(/stack-unit 0 provision (.*)/)
+          item = match_data[1] unless match_data.nil?
+        end
       end
       cmd CMD_SHOW_SYSTEM_STACK_UNIT_IOM
     end

--- a/lib/puppet_x/force10/transport/ssh.rb
+++ b/lib/puppet_x/force10/transport/ssh.rb
@@ -71,11 +71,18 @@ class PuppetX::Force10::Transport::Ssh < Puppet::Util::NetworkDevice::Transport:
       send(cmd, noop)
       unless noop
         @cache[cmd] = expect(options[:prompt] || default_prompt)
+        txt = @cache[cmd]
+        if !txt.nil?
+          raise(ArgumentError, "Invalid Command:\t #{cmd} while configuring switch") if txt =~ /\sError: ((Invalid input)|(Incomplete command))\s/
+        end
       end
     else
       send(cmd, noop)
       unless noop
         expect(options[:prompt] || default_prompt) do |output|
+          if !output.nil?
+            raise(ArgumentError, "Invalid Command:\t #{cmd} while loading facts") if txt =~ /\sError: ((Invalid input)|(Incomplete command))\s/
+          end
           yield output if block_given?
         end
       end

--- a/spec/fixtures/show_interfaces_switchport/show_switch_no_spt.out
+++ b/spec/fixtures/show_interfaces_switchport/show_switch_no_spt.out
@@ -1,10 +1,11 @@
 !
 interface TenGigabitEthernet 0/14
- no ip address
- mtu 12000
- portmode hybrid
- switchport
- spanning-tree 0 portfast
+  no ip address
+  mtu 12000
+  portmode hybrid
+  switchport
+  spanning-tree 0 portfast
+ !
+  protocol lldp
+  no shutdown
 !
- protocol lldp
- no shutdown

--- a/spec/unit/puppet_x/force10/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface/base_spec.rb
@@ -5,179 +5,158 @@ describe PuppetX::Force10::Model::Interface::Base do
   let(:base) { PuppetX::Force10::Model::Interface::Base }
   let(:transport) { stub("rspec-transport") }
 
-  describe "#vlans_from_list" do
-    it "should return a single vlan as a list" do
-      expect(base.vlans_from_list("20")).to eq(["20"])
-    end
-
-    it "should return empty string as an empty list" do
-      expect(base.vlans_from_list("")).to eq([])
-    end
-
-    it "should split comma-separated vlans" do
-      expect(base.vlans_from_list("20,21,22")).to eq(%w(20 21 22))
-    end
-
-    it "should handle ranges" do
-      expect(base.vlans_from_list("18,20-22,28")).to eq(%w(18 20 21 22 28))
-    end
-  end
-
   describe "#show_interface_vlans" do
     it "should parse only untagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/only_untagged.out")
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", []])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[25], []])
     end
 
     it "should parse untagged and tagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/tagged_and_untagged.out")
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["18", %w(16 20 23 28)])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[18], [16, 20, 23, 28]])
     end
 
     it "should parse untagged and tagged vlan ranges" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/tagged_with_ranges.out")
       transport = Object.new
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", %w(18 19 20 21 28)])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[25], [18, 19, 20, 21, 28]])
     end
   end
 
-  describe "#update_vlans" do
-    let(:interface_type) { "Tengigabit" }
-    let(:interface_id) { "0/4" }
-    let(:interface_info) { [interface_type, interface_id] }
+  describe "#update_untagged_vlans" do
+    it "should unset untagged vlan" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "20", [18], "Te 0/14")
+    end
+
+    it "should add untagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "20", [1], "Te 0/14")
+    end
+
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "1", [18], "Te 0/14")
+    end
+  end
+
+  describe "#update_tagged_vlans" do
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "20", [18, 20], "Te 0/14")
+    end
 
     it "should add tagged vlans" do
-      expect(base).to receive(:show_interface_vlans)
-          .with(transport, interface_type, interface_id)
-          .and_return(["1", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
       expect(transport).to receive(:command).with("config").ordered
       expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "20", [], "Te 0/14")
+    end
+
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should add tagged vlans and unset extra tagged" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", ["18"]])
-      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
       expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should add tagged vlans and unset any that are untagged" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["20", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should set untagged vlan" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 1").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["18"], false, interface_info)
-    end
-
-    it "should set untagged vlan and remove from tagged if needed" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", ["18"]])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 1").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["18"], false, interface_info)
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "28", [18, 20], "Te 0/14")
     end
   end
 
   describe "#show_stp_val" do
     let(:interface_type) { "Te 0/14" }
-    it "should parse only existing spanning-tree protcol edge-port"do
+    it "should parse only existing spanning-tree protcol edge-port" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/show_switch_spt.out")
       transport.stub(:command).with("show config").and_return(out)
-      expect(base.show_stp_val(transport,"Te 0/14")).to eq(["mstp","rstp","pvst"])
+      expect(base.show_stp_val(transport, "Te 0/14")).to eq(["mstp", "rstp", "pvst"])
     end
-    it "should parse no spanning-tree edge-port"do
+    it "should parse no spanning-tree edge-port" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/show_switch_no_spt.out")
       transport.stub(:command).with("show config").and_return(out)
-      expect(base.show_stp_val(transport,"Te 0/14")).to eq([])
+      expect(base.show_stp_val(transport, "Te 0/14")).to eq([])
     end
   end
 
-  describe "#update_stp"do
-    it "should add valid spanning-tree protocol type"do
-     expect(transport).to receive(:command).with("config").ordered
-     expect(transport).to receive(:command).with("interface Te 0/14").ordered
-     expect(transport).to receive(:command).with("spanning-tree mvst edge-port").ordered
-     expect(transport).to receive(:command).with("config").ordered
-     expect(transport).to receive(:command).with("interface Te 0/14").ordered
-     expect(transport).to receive(:command).with("spanning-tree rstp edge-port").ordered
-     base.update_stp(transport,"Te 0/14",["pvst"],["mvst","rstp","pvst"])
+  describe "#update_stp" do
+    it "should add valid spanning-tree protocol type" do
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree mvst edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree rstp edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_stp(transport, "Te 0/14", ["pvst"], ["mvst", "rstp", "pvst"])
     end
 
-    it "should add correct spanning-tree protocol type"do
-      expect(transport).to receive(:command).with("config").ordered
+    it "should add correct spanning-tree protocol type" do
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("no spanning-tree mvst edge-port").ordered
-      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("no spanning-tree rstp edge-port").ordered
-      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
-      base.update_stp(transport,"Te 0/14", ["mvst","rstp"],["pvst"])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_stp(transport, "Te 0/14", ["mvst", "rstp"], ["pvst"])
     end
 
-     it "should add parsed spanning-tree protocol type"do
-       expect(transport).to receive(:command).with("config").ordered
-       expect(transport).to receive(:command).with("interface Te 0/14").ordered
-       expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
-       base.update_stp(transport,"Te 0/14", [],["pvst"])
-     end
- end
+    it "should add parsed spanning-tree protocol type" do
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_stp(transport, "Te 0/14", [], ["pvst"])
+    end
+  end
 end
-
-
-
-

--- a/spec/unit/puppet_x/force10/model/interface_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface_spec.rb
@@ -101,7 +101,7 @@ describe PuppetX::Force10::Model::Interface do
       interface.update(old_params, new_params)
     end
 
-    it 'should setup spanning-tree portfast' do
+    it 'should setup spanning-tree edge-port' do
       name = 'TenGigabitEthernet 0/7'
       interface = PuppetX::Force10::Model::Interface.new(@transport, @config, {:name=>name})
       interface.retrieve
@@ -109,9 +109,10 @@ describe PuppetX::Force10::Model::Interface do
       new_params = old_params.dup
       new_params[:edge_port] = 'pvst'
       @transport.should_receive(:command).with("show config")
-      @transport.should_receive(:command).with("config")
+      @transport.should_receive(:command).with("exit")
       @transport.should_receive(:command).with("interface TenGigabitEthernet 0/7")
       @transport.should_receive(:command).with("spanning-tree pvst edge-port")
+      @transport.should_receive(:command).with("exit")
       interface.update(old_params, new_params)
     end
   end


### PR DESCRIPTION
code changes will some of Invalid commands in puppet model, while loading facts on switch.some invalid commands are 
1) Try to update default untagged vlan (1) which is invalid 
2) Error commands on stack-unit iom mode command while loading facts 
3)removed some commands which are like switch are already in config sate try to reenter it again will resolve these changes. 