### PR TITLE
ASM-7311 Always send a 'no switchport' command with portchannel

### DIFF
--- a/lib/puppet_x/force10/model/interface/base.rb
+++ b/lib/puppet_x/force10/model/interface/base.rb
@@ -55,6 +55,11 @@ module PuppetX::Force10::Model::Interface::Base
         if existing_config.find {|line| line =~ /port-channel/}
           transport.command("no port-channel-protocol lacp")
         end
+
+        # ASM-7311 even if the port doesn't say it's in switchport mode,the
+        # 'no switchport' command is still necessary at times, otherwise the lacp
+        # commands will fail. Shouldn't hurt to just run the command everytime
+        transport.command("no switchport")
         transport.command("port-channel-protocol lacp")
         transport.command("port-channel #{value} mode active")
         transport.command("exit")


### PR DESCRIPTION
For whatever reason, sometimes the port-channel-protocol command on
on a port will fail until 'no switchport' command is given. Since we
are already attempting to turn switchport mode off if it's enabled
anyway, we just ensure the command is run everytime, regardless of
whether it shows in the port's config.