### PR TITLE
[DNM] ASM-6083 Will Address force10 Inavlid commands during service deployment

### DIFF
--- a/lib/puppet_x/force10/transport/ssh.rb
+++ b/lib/puppet_x/force10/transport/ssh.rb
@@ -71,11 +71,18 @@ class PuppetX::Force10::Transport::Ssh < Puppet::Util::NetworkDevice::Transport:
       send(cmd, noop)
       unless noop
         @cache[cmd] = expect(options[:prompt] || default_prompt)
+        txt = @cache[cmd]
+        if !txt.nil?
+          raise(ArgumentError, "Invalid Command:\t #{cmd} while configuring switch") if txt =~ /\sError: (Incomplete command)\s/
+        end
       end
     else
       send(cmd, noop)
       unless noop
         expect(options[:prompt] || default_prompt) do |output|
+          if !output.nil?
+            raise(ArgumentError, "Invalid Command:\t #{cmd} while loading facts") if txt =~ /\sError: (Incomplete command)\s/
+          end
           yield output if block_given?
         end
       end

--- a/spec/unit/puppet_x/force10/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface/base_spec.rb
@@ -5,131 +5,109 @@ describe PuppetX::Force10::Model::Interface::Base do
   let(:base) { PuppetX::Force10::Model::Interface::Base }
   let(:transport) { stub("rspec-transport") }
 
-  describe "#vlans_from_list" do
-    it "should return a single vlan as a list" do
-      expect(base.vlans_from_list("20")).to eq(["20"])
-    end
-
-    it "should return empty string as an empty list" do
-      expect(base.vlans_from_list("")).to eq([])
-    end
-
-    it "should split comma-separated vlans" do
-      expect(base.vlans_from_list("20,21,22")).to eq(%w(20 21 22))
-    end
-
-    it "should handle ranges" do
-      expect(base.vlans_from_list("18,20-22,28")).to eq(%w(18 20 21 22 28))
-    end
-  end
-
   describe "#show_interface_vlans" do
     it "should parse only untagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/only_untagged.out")
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", []])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[25], []])
     end
 
     it "should parse untagged and tagged vlan" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/tagged_and_untagged.out")
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["18", %w(16 20 23 28)])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[18], [16, 20, 23, 28]])
     end
 
     it "should parse untagged and tagged vlan ranges" do
       out = PuppetSpec.load_fixture("show_interfaces_switchport/tagged_with_ranges.out")
       transport = Object.new
-      transport.stub(:command).with("show interfaces switchport Tengigabitethernet 0/4").and_return(out)
-      expect(base.show_interface_vlans(transport, "Tengigabitethernet", "0/4")).to eq(["25", %w(18 19 20 21 28)])
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      transport.stub(:command).with("show interfaces switchport Te 0/4").and_return(out)
+      expect(base.show_interface_vlans(transport, "Te 0/4")).to eq([[25], [18, 19, 20, 21, 28]])
     end
   end
 
-  describe "#update_vlans" do
-    let(:interface_type) { "Tengigabit" }
-    let(:interface_id) { "0/4" }
-    let(:interface_info) { [interface_type, interface_id] }
+  describe "#update_untagged_vlans" do
+    it "should unset untagged vlan" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "20", [18], "Te 0/14")
+    end
+
+    it "should add untagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "20", [1], "Te 0/14")
+    end
+
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no untagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_untagged_vlans(transport, "1", [18], "Te 0/14")
+    end
+  end
+
+  describe "#update_tagged_vlans" do
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "20", [18, 20], "Te 0/14")
+    end
 
     it "should add tagged vlans" do
-      expect(base).to receive(:show_interface_vlans)
-          .with(transport, interface_type, interface_id)
-          .and_return(["1", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
       expect(transport).to receive(:command).with("config").ordered
       expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
+      expect(transport).to receive(:command).with("tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "20", [], "Te 0/14")
+    end
+
+    it "should unset extra tagged vlans" do
+      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("interface vlan 18").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface vlan 20").ordered
+      expect(transport).to receive(:command).with("no tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should add tagged vlans and unset extra tagged" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", ["18"]])
-      expect(transport).to receive(:command).twice.with("exit").ordered
+      expect(transport).to receive(:command).with("tagged Te 0/14").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("show interfaces switchport Te 0/14").ordered
       expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should add tagged vlans and unset any that are untagged" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["20", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 20").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface vlan 28").ordered
-      expect(transport).to receive(:command).with("tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["20", "28"], true, interface_info)
-    end
-
-    it "should set untagged vlan" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", []])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 1").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["18"], false, interface_info)
-    end
-
-    it "should set untagged vlan and remove from tagged if needed" do
-      expect(base).to receive(:show_interface_vlans)
-                          .with(transport, interface_type, interface_id)
-                          .and_return(["1", ["18"]])
-      expect(transport).to receive(:command).twice.with("exit").ordered
-      expect(transport).to receive(:command).with("config").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("no tagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 1").ordered
-      expect(transport).to receive(:command).with("no untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("exit").ordered
-      expect(transport).to receive(:command).with("interface vlan 18").ordered
-      expect(transport).to receive(:command).with("untagged Tengigabit 0/4").ordered
-      expect(transport).to receive(:command).with("interface Tengigabit 0/4").ordered
-      base.update_vlans(transport, ["18"], false, interface_info)
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_tagged_vlans(transport, "28", [18, 20], "Te 0/14")
     end
   end
+
 
   describe "#show_stp_val" do
     let(:interface_type) { "Te 0/14" }
@@ -146,38 +124,41 @@ describe PuppetX::Force10::Model::Interface::Base do
   end
 
   describe "#update_stp"do
-    it "should add valid spanning-tree protocol type"do
-     expect(transport).to receive(:command).with("config").ordered
-     expect(transport).to receive(:command).with("interface Te 0/14").ordered
-     expect(transport).to receive(:command).with("spanning-tree mvst edge-port").ordered
-     expect(transport).to receive(:command).with("config").ordered
-     expect(transport).to receive(:command).with("interface Te 0/14").ordered
-     expect(transport).to receive(:command).with("spanning-tree rstp edge-port").ordered
-     base.update_stp(transport,"Te 0/14",["pvst"],["mvst","rstp","pvst"])
+    it "should add valid spanning-tree protocol type" do
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree mvst edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      expect(transport).to receive(:command).with("spanning-tree rstp edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
+      base.update_stp(transport, "Te 0/14", ["pvst"], ["mvst", "rstp", "pvst"])
     end
 
     it "should add correct spanning-tree protocol type"do
-      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("no spanning-tree mvst edge-port").ordered
-      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("no spanning-tree rstp edge-port").ordered
-      expect(transport).to receive(:command).with("config").ordered
+      expect(transport).to receive(:command).with("exit").ordered
       expect(transport).to receive(:command).with("interface Te 0/14").ordered
       expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
+      expect(transport).to receive(:command).with("exit").ordered
+      expect(transport).to receive(:command).with("interface Te 0/14").ordered
       base.update_stp(transport,"Te 0/14", ["mvst","rstp"],["pvst"])
     end
 
      it "should add parsed spanning-tree protocol type"do
-       expect(transport).to receive(:command).with("config").ordered
+       expect(transport).to receive(:command).with("exit").ordered
        expect(transport).to receive(:command).with("interface Te 0/14").ordered
        expect(transport).to receive(:command).with("spanning-tree pvst edge-port").ordered
+       expect(transport).to receive(:command).with("exit").ordered
+       expect(transport).to receive(:command).with("interface Te 0/14").ordered
        base.update_stp(transport,"Te 0/14", [],["pvst"])
      end
  end
 end
-
-
-
 

--- a/spec/unit/puppet_x/force10/model/interface_spec.rb
+++ b/spec/unit/puppet_x/force10/model/interface_spec.rb
@@ -103,7 +103,7 @@ describe PuppetX::Force10::Model::Interface do
       interface.update(old_params, new_params)
     end
 
-    it 'should setup spanning-tree portfast' do
+    it 'should setup spanning-tree edge-port' do
       name = 'TenGigabitEthernet 0/7'
       interface = PuppetX::Force10::Model::Interface.new(@transport, @config, {:name=>name})
       interface.retrieve
@@ -111,9 +111,9 @@ describe PuppetX::Force10::Model::Interface do
       new_params = old_params.dup
       new_params[:edge_port] = 'pvst'
       @transport.should_receive(:command).with("show config")
-      @transport.should_receive(:command).with("config")
+      @transport.should_receive(:command).with("exit")
+      @transport.should_receive(:command).with("exit")
       @transport.should_receive(:command).with("interface TenGigabitEthernet 0/7")
-      @transport.should_receive(:command).with("spanning-tree pvst edge-port")
       interface.update(old_params, new_params)
     end
   end


### PR DESCRIPTION
Below changes will address the failure causing force10 switch commands 
1) Switch is in config state try to enter config state Error 
2) updating untagged vlan when it set to "1" Error 
3) When developer enters Incomplete command for instance 
show running-config interface Te,  In this scenario switch configuration failure by raising exception. 
