### PR TITLE
ASM-7342 Portchannel resources weren't properly matching existing config

### DIFF
--- a/lib/puppet_x/force10/model/portchannel.rb
+++ b/lib/puppet_x/force10/model/portchannel.rb
@@ -58,10 +58,8 @@ class PuppetX::Force10::Model::Portchannel < PuppetX::Force10::Model::Base
 
   def before_update(params_to_update=[])
     super
-    #
-    #Dell(conf)#interface port-channel 1
-    #Error: Command allowed only for uplink Lag.
     full_name = "po %s" % name
+
     # Need to remove portchannel from all vlans if we want to change the portmode
     if params_to_update.collect{|param| param.name}.include?(:portmode)
       Puppet.info("Removing all vlans for %s so portmode can be set." % full_name)

--- a/lib/puppet_x/force10/model/scoped_value.rb
+++ b/lib/puppet_x/force10/model/scoped_value.rb
@@ -1,4 +1,14 @@
 #The class has the methods for parsing and keeping parameters of resource type(Like vlan, portchannel etc) values
+
+# Scope should be some form of regex that will capture both the main
+# config of the scope we're looking for, and the name of the scope.
+# Example: We want to find the config of vlan 25. We run 'show running-config' as
+# the command to find the scope's (vlan 25's) configuration. Our scope should be
+# one that gives us back match data that has both the config for vlan 25, and 25
+# (the name of the scope). So, we might have a scope like /^(interface Vlan\s+(\S+).*?)^!/m
+# Using txt.scan with that scope will return back something like [[<config text>, "25"]],
+# which the code will then parse out to match the individual parameter that is
+# trying to be matched/configured.
 require 'puppet_x/force10/model'
 require 'puppet_x/force10/model/generic_value'
 require 'puppet/util/monkey_patches_ftos'


### PR DESCRIPTION
This led to issues of some config being removed/added every time we ran
puppet config, instead of skipping as you would expect. Particularly,
when configuring portmode, we remove existing config/vlans and that was
happening on every run, even if portmode was properly set