### PR TITLE
ASM-7574 Force10 TOR switch configuration when there is ">" in output of running-configuration

### DIFF
--- a/lib/puppet_x/force10/transport.rb
+++ b/lib/puppet_x/force10/transport.rb
@@ -35,7 +35,7 @@ module PuppetX
           end
         end
 
-        @session.default_prompt = /[#>]\s?\z/n
+        @session.default_prompt = /^\S+[#>]\s?\z/n
         connect_session
         init_facts
         init_switch


### PR DESCRIPTION
Force10 discovery and configuration command intermittently fails when there is ">" or ">>" character in the running configuration output.