### PR TITLE
ASM-7652 Some IOAs would hang due to randomly returning DOS line endings

### DIFF
--- a/lib/puppet_x/force10/transport.rb
+++ b/lib/puppet_x/force10/transport.rb
@@ -35,7 +35,7 @@ module PuppetX
           end
         end
 
-        @session.default_prompt = /^\S+[#>]\s?\z/n
+        @session.default_prompt = /^\s?\S+[#>]\s?\z/n
         connect_session
         init_facts
         init_switch


### PR DESCRIPTION
Carriage return in the line ending was messing up our prompt for our SSH
expects, so some lines were hanging due to the carriage return being
seen as the beginning of the line that should have matched.