### PR TITLE
ASM-8827  Puppet4 compliance

### DIFF
--- a/lib/puppet_x/force10/dsl.rb
+++ b/lib/puppet_x/force10/dsl.rb
@@ -54,7 +54,7 @@ module PuppetX::Force10::Dsl
     @included_modules ||= []
     unless @included_modules.include?(mod)
 
-      Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition), :wrap => false).load(mod)
+      Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition)).load(mod)
       if path_addition.empty?
         mod_const_base.const_get(mod.to_s.capitalize).register(self)
         @included_modules << mod


### PR DESCRIPTION
The `:wrap` parameter is not valid for puppet 4.  I've tested this
to make sure the module still works on the old puppet wth discovery
and basic deployment.

Because a lot of this code was copy-pasted, I have a feeling this
was nevery needed (especially because it's set to false)