### PR TITLE
ASM-9659 Fix non-disruptive update to skip network configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake'
-  gem 'rspec'
-  gem 'puppetlabs_spec_helper'
+  gem 'rspec', '~>3.4.0', :require => false
+  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
   gem 'json_pure', '2.0.1'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion

--- a/lib/puppet/type/force10_interface.rb
+++ b/lib/puppet/type/force10_interface.rb
@@ -86,5 +86,9 @@ Puppet::Type.newtype(:force10_interface) do
     desc "untagged vlan"
   end
 
+  newproperty(:inclusive_vlans) do
+    desc "Flag to indicate if existing vlans needs to be included"
+    newvalues(:true, :false)
+  end
 end
 

--- a/lib/puppet/type/force10_portchannel.rb
+++ b/lib/puppet/type/force10_portchannel.rb
@@ -93,6 +93,11 @@ Puppet::Type.newtype(:force10_portchannel) do
     end
   end
 
+  newproperty(:inclusive_vlans) do
+    desc "Flag to indicate if existing vlans needs to be included"
+    newvalues(:true, :false)
+  end
+
   newproperty(:portfast) do
     desc "property to set the spanning tree portfast setting"
     newvalues("portfast")

--- a/lib/puppet_x/force10/model/portchannel/base.rb
+++ b/lib/puppet_x/force10/model/portchannel/base.rb
@@ -34,7 +34,8 @@ module PuppetX::Force10::Model::Portchannel::Base
       end
       add do |transport, value|
         vlans = PuppetX::Force10::Model::Interface::Base.vlans_from_list(value)
-        PuppetX::Force10::Model::Interface::Base.update_vlans(transport, vlans, true, ["po", base.name])
+        inclusive_vlans = base.params[:inclusive_vlans].value
+        PuppetX::Force10::Model::Interface::Base.update_vlans(transport, vlans, true, ["po", base.name], inclusive_vlans)
       end
       remove { |*_| }
     end


### PR DESCRIPTION
Added support for new property "inclusive_vlans". When value if set to true then all existing vlans on the interface is retained and provided vlan is added to the list.