### PR TITLE
VXFM-2167 Discover and service deployment s5048 support FTOS 9.11, 9.12 and S5048 switch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion
   else
-    gem 'puppet', '3.6.2'
+    gem 'puppet', '5.3.3'
   end
 end
 

--- a/lib/puppet/provider/force10_interface/dell_ftos.rb
+++ b/lib/puppet/provider/force10_interface/dell_ftos.rb
@@ -7,8 +7,9 @@ Puppet::Type.type(:force10_interface).provide :dell_ftos, :parent => Puppet::Pro
   def self.get_current(name)
     if !name.nil?
       name=name.gsub(/te |tengigabitethernet /i, "TenGigabitEthernet ")
-
+      name=name.gsub(/tf |twentyfivegige /i, "twentyFiveGigE ")
       name=name.gsub(/fo |fortygige /i, "fortyGigE ")
+      name=name.gsub(/hu |hundredgige /i, "hundredGigE ")
     end
     transport.switch.interface(name).params_to_hash
   end
@@ -22,14 +23,22 @@ Puppet::Type.type(:force10_interface).provide :dell_ftos, :parent => Puppet::Pro
     vlan_info = get_vlan_info
     iface = get_iface
     iface = iface.gsub(/te |tengigabitethernet /i, "Tengigabitethernet ")
+    iface = iface.gsub(/tf |twentyfivegige /i, "twentyFiveGigE ")
     iface = iface.gsub(/fo |fortygige /i, "Fortygige ")
+    iface = iface.gsub(/hu |hundredgige /i, "hundredGigE ")
     # Name translation to map puppet resource name to fact key
     if iface.include? 'Tengigabitethernet'
       iface.slice! 'Tengigabitethernet '
       type = 'tengigabit'
+    elsif iface.include? 'twentyFiveGigE'
+      iface.slice! 'twentyFiveGigE '
+      type = 'twentyfivegigabit'
     elsif iface.include? 'Fortygige'
       iface.slice! 'Fortygige '
       type = 'fortygigabit'
+    elsif iface.include? 'hundredGigE'
+      iface.slice! 'hundredGigE '
+      type = 'hundredgigabit'
     else
       raise Puppet::Error, "Unknown interface type #{iface}"
     end
@@ -46,7 +55,9 @@ Puppet::Type.type(:force10_interface).provide :dell_ftos, :parent => Puppet::Pro
       # translate fact key to switch command
       iface_map = {
           'tengigabit' => 'tengigabitethernet',
+          'twentyfivegigabit' => 'twentyFiveGigE',
           'fortygigabit' => 'fortyGigE',
+          'hundredgigabit' => 'hundredGigE',
           'gigabit' => 'gigabitethernet'
       }
       transport.session.command('configure', :prompt => /\(conf\)#\s?\z/n)

--- a/lib/puppet/type/force10_interface.rb
+++ b/lib/puppet/type/force10_interface.rb
@@ -6,7 +6,7 @@ Puppet::Type.newtype(:force10_interface) do
   newparam(:name) do
     desc "Interface name, represents an interface"
     isrequired
-    newvalues(/^\Atengigabitethernet\s*\S+/i, /te\s*\S+$/i,/^fortygige\s*\S+$/i,/^fo\s*\S+$/i)
+    newvalues(/^\Atengigabitethernet\s*\S+/i, /te\s*\S+$/i, /^fortygige\s*\S+$/i, /^fo\s*\S+$/i, /^twentyfivegige\s*\S+$/i, /tf\s*\S+$/i, /^hundredgige\s*\S+$/i, /hu\s*\S+$/i)
     isnamevar
   end
 

--- a/lib/puppet/type/force10_vlan.rb
+++ b/lib/puppet/type/force10_vlan.rb
@@ -65,8 +65,16 @@ Puppet::Type.newtype(:force10_vlan) do
     desc "The TenGigabitEthernet interfaces names to add as tagged to this VLAN."
   end
 
+  newproperty(:tagged_twentyfivegigabitethernet) do
+    desc "The twentyFiveGigE interfaces names to add as tagged to this VLAN."
+  end
+
   newproperty(:tagged_fortygigabitethernet) do
     desc "The fortyGigE interfaces names to add as tagged to this VLAN."
+  end
+
+  newproperty(:tagged_hundredgigabitethernet) do
+    desc "The hundredGigE interfaces names to add as tagged to this VLAN."
   end
 
   newproperty(:tagged_portchannel) do
@@ -85,8 +93,16 @@ Puppet::Type.newtype(:force10_vlan) do
     desc "The TenGigabitEthernet interfaces names to add as untagged to this VLAN."
   end
 
+  newproperty(:untagged_twentyfivegigabitethernet) do
+    desc "The twentyFiveGigE interfaces names to add as untagged to this VLAN."
+  end
+
   newproperty(:untagged_fortygigabitethernet) do
     desc "The fortyGigE interfaces names to add as untagged to this VLAN."
+  end
+
+  newproperty(:untagged_hundredgigabitethernet) do
+    desc "The hundredGigE interfaces names to add as tagged to this VLAN."
   end
 
   newproperty(:untagged_portchannel) do

--- a/lib/puppet_x/force10/model/interface.rb
+++ b/lib/puppet_x/force10/model/interface.rb
@@ -28,12 +28,16 @@ class PuppetX::Force10::Model::Interface < PuppetX::Force10::Model::Base
   end
 
   def before_update(params_to_update=[])
-    transport.command("show interfaces #{@name}")do |out|
+    new_name = @name.gsub(/te |tengigabitethernet /i, "Tengigabitethernet ")
+    new_name = new_name.gsub(/tf |twentyfivegige /i, "twentyFiveGigE ")
+    new_name = new_name.gsub(/fo |fortygige /i, "Fortygige ")
+    new_name = new_name.gsub(/hu |hundredgige /i, "hundredGigE ")
+    transport.command("show interfaces #{new_name}")do |out|
       if out =~/Error:\s*(.*)/
         Puppet.debug "errror msg ::::#{$1}"
         Puppet.debug("Wait for 1 minute before re-validating")
         sleep(60)
-        new_out = transport.command("show interfaces #{@name}")
+        new_out = transport.command("show interfaces #{new_name}")
         raise "The entered interface does not exist. Enter the correct interface." if new_out =~/Error:\s*(.*)/
       end
     end
@@ -47,7 +51,7 @@ class PuppetX::Force10::Model::Interface < PuppetX::Force10::Model::Base
       transport.command("exit")
     end
 
-    transport.command("interface #{@name}", :prompt => /\(conf-if-\S+\)#\z/n)
+    transport.command("interface #{new_name}", :prompt => /\(conf-if-\S+\)#\z/n)
   end
 
 end

--- a/lib/puppet_x/force10/model/interface/base.rb
+++ b/lib/puppet_x/force10/model/interface/base.rb
@@ -350,9 +350,15 @@ module PuppetX::Force10::Model::Interface::Base
     if iface.include? 'TenGigabitEthernet'
       iface.slice! 'TenGigabitEthernet '
       type = 'TenGigabitEthernet'
+    elsif iface.include? 'twentyFiveGigE'
+      iface.slice! 'twentyFiveGigE '
+      type = 'twentyFiveGigE'
     elsif iface.include? 'FortyGigE'
       iface.slice! 'FortyGigE '
       type = 'fortyGigE'
+    elsif iface.include? 'hundredGigE'
+      iface.slice! 'hundredGigE '
+      type = 'hundredGigE'
     else
       raise Puppet::Error, "Unknown interface type #{iface}"
     end

--- a/lib/puppet_x/force10/model/vlan/base.rb
+++ b/lib/puppet_x/force10/model/vlan/base.rb
@@ -109,43 +109,29 @@ module PuppetX::Force10::Model::Vlan::Base
       end
     end
 
-    base.register_scoped :tagged_tengigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*tagged TenGigabitEthernet\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          transport.command("no untagged TenGigabitEthernet #{value}")
-          transport.command("tagged TenGigabitEthernet #{value}") do |out|
-            txt<< out
+    [[:tagged_gigabitethernet, "GigabitEthernet"],
+     [:tagged_tengigabitethernet, "TenGigabitEthernet"],
+     [:tagged_twentyfivegigabitethernet, "twentyFiveGigE"],
+     [:tagged_fortygigabitethernet, "fortyGigE"],
+     [:tagged_hundredgigabitethernet, "hundredGigE"]].each do |tagged_param, port_speed|
+      base.register_scoped tagged_param, /^(interface Vlan\s+(\S+).*?)^!/m do
+        match /^\s*tagged #{port_speed}\s+(.*?)\s*$/
+        cmd 'sh run'
+        add do |transport, value|
+          if value != 'absent'
+            transport.command("no untagged #{port_speed} #{value}")
+            transport.command("tagged #{port_speed} #{value}") do |out|
+              txt << out
+            end
+            parseforerror(txt, "add the property value for the parameter 'tagged #{port_speed}'")
           end
-          parseforerror(txt,"add the property value for the parameter 'tagged TenGigabitEthernet'")
         end
-      end
-      remove do |transport, old_value|
-        #transport.command("no tagged TenGigabitEthernet #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the old property value of the parameter 'tagged TenGigabitEthernet'")
-      end
-    end
-
-    base.register_scoped :tagged_fortygigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*tagged fortyGigE\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          transport.command("no untagged fortyGigE #{value}")
-          transport.command("tagged fortyGigE #{value}") do |out|
-            txt<< out
-          end
-          parseforerror(txt,"add the property value for the parameter 'tagged fortyGigE'")
+        remove do |transport, old_value|
+          #transport.command("no tagged TenGigabitEthernet #{old_value}") do |out|
+          #  txt<< out
+          #end
+          parseforerror(txt, "remove the old property value of the parameter 'tagged #{port_speed}'")
         end
-      end
-      remove do |transport, old_value|
-        #transport.command("no tagged fortyGigE #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the old property value of the parameter 'tagged fortyGigE'")
       end
     end
 
@@ -169,26 +155,6 @@ module PuppetX::Force10::Model::Vlan::Base
       end
     end
 
-    base.register_scoped :tagged_gigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*tagged GigabitEthernet\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          transport.command("no untagged GigabitEthernet #{value}")
-          transport.command("tagged GigabitEthernet #{value}") do |out|
-            txt<< out
-          end
-          parseforerror(txt,"add the property value for the parameter 'tagged GigabitEthernet'")
-        end
-      end
-      remove do |transport, old_value|
-        #transport.command("no tagged GigabitEthernet #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the property value of the parameter 'tagged GigabitEthernet'")
-      end
-    end
-
     base.register_scoped :tagged_sonet, /^(interface Vlan\s+(\S+).*?)^!/m do
       match /^\s*tagged Sonet\s+(.*?)\s*$/
       cmd 'sh run'
@@ -209,46 +175,31 @@ module PuppetX::Force10::Model::Vlan::Base
       end
     end
 
-    base.register_scoped :untagged_tengigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*untagged TenGigabitEthernet\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          #untagged interfaces can only belong to one VLAN at a time - and so checking for mappings and so doing no untag
-          nountagintffromoothervlans("TenGigabitEthernet",value,base.name)
-          transport.command("no tagged TenGigabitEthernet #{value}")
-          transport.command("untagged TenGigabitEthernet #{value}") do |out|
-            txt<< out
+    [[:untagged_gigabitethernet, "GigabitEthernet"],
+     [:untagged_tengigabitethernet, "TenGigabitEthernet"],
+     [:untagged_twentyfivegigabitethernet, "twentyFiveGigE"],
+     [:untagged_fortygigabitethernet, "fortyGigE"],
+     [:untagged_hundredgigabitethernet, "hundredGigE"]].each do |tagged_param, port_speed|
+      base.register_scoped tagged_param, /^(interface Vlan\s+(\S+).*?)^!/m do
+        match /^\s*tagged #{port_speed}\s+(.*?)\s*$/
+        cmd 'sh run'
+        add do |transport, value|
+          if value != 'absent'
+            #untagged interfaces can only belong to one VLAN at a time - and so checking for mappings and so doing no untag
+            nountagintffromoothervlans(port_speed,value,base.name)
+            transport.command("no tagged #{port_speed} #{value}")
+            transport.command("untagged #{port_speed} #{value}") do |out|
+              txt << out
+            end
+            parseforerror(txt, "add the property value for the parameter 'untagged #{port_speed}'")
           end
-          parseforerror(txt,"add the property value for the parameter 'untagged TenGigabitEthernet'")
         end
-      end
-      remove do |transport, old_value|
-        #transport.command("no untagged TenGigabitEthernet #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the old property value of the parameter 'untagged TenGigabitEthernet'")
-      end
-    end
-
-    base.register_scoped :untagged_fortygigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*untagged fortyGigE\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          nountagintffromoothervlans("fortyGigE",value,base.name)
-          transport.command("no tagged fortyGigE #{value}")
-          transport.command("untagged fortyGigE #{value}") do |out|
-            txt<< out
-          end
-          parseforerror(txt,"add the property value for the parameter 'untagged fortyGigE'")
+        remove do |transport, old_value|
+          #transport.command("no untagged TenGigabitEthernet #{old_value}") do |out|
+          #  txt<< out
+          #end
+          parseforerror(txt, "remove the old property value of the parameter 'untagged #{port_speed}'")
         end
-      end
-      remove do |transport, old_value|
-        #transport.command("no untagged fortyGigE #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the old property value of the parameter 'untagged fortyGigE'")
       end
     end
 
@@ -273,27 +224,6 @@ module PuppetX::Force10::Model::Vlan::Base
         # txt<< out
         #end
         parseforerror(txt,"to remove the old property value of the parameter 'untagged Port-channel'")
-      end
-    end
-
-    base.register_scoped :untagged_gigabitethernet, /^(interface Vlan\s+(\S+).*?)^!/m do
-      match /^\s*untagged GigabitEthernet\s+(.*?)\s*$/
-      cmd 'sh run'
-      add do |transport, value|
-        if value != 'absent'
-          nountagintffromoothervlans("GigabitEthernet",value,base.name)
-          transport.command("no tagged GigabitEthernet #{value}")
-          transport.command("untagged GigabitEthernet #{value}") do |out|
-            txt<< out
-          end
-          parseforerror(txt,"add the property value for the parameter 'untagged GigabitEthernet'")
-        end
-      end
-      remove do |transport, old_value|
-        #transport.command("no untagged GigabitEthernet #{old_value}") do |out|
-        #  txt<< out
-        #end
-        parseforerror(txt,"remove the property value of the parameter 'untagged GigabitEthernet'")
       end
     end
 

--- a/lib/puppet_x/force10/possible_facts/base.rb
+++ b/lib/puppet_x/force10/possible_facts/base.rb
@@ -151,14 +151,14 @@ module PuppetX::Force10::PossibleFacts::Base
 
     base.register_param 'dell_force10_operating_system_version' do
       match do |txt|
-        version = txt.scan(/^Dell\s+Force10\s+Operating\s+System\s+Version:\s+(\S+)$|Dell Operating System Version:\s+(.*?)$/m).flatten.compact.first
+        version = txt.scan(/^Dell\s+Force10\s+Operating\s+System\s+Version:\s+(\S+)$|Dell Operating System Version:\s+(.*?)$|Dell EMC Operating System Version:\s+(.*?)$/m).flatten.compact.first
       end
       cmd CMD_SHOW_VERSION
     end
 
     base.register_param 'dell_force10_application_software_version' do
       match do |txt|
-        version = txt.scan(/^Dell\s+Force10\s+Application\s+Software\s+Version:\s+(\S+)$|Dell Application Software Version:\s+(.*?)$/m).flatten.compact.first
+        version = txt.scan(/^Dell\s+Force10\s+Application\s+Software\s+Version:\s+(\S+)$|Dell Application Software Version:\s+(.*?)$|Dell EMC Application Software Version:\s+(.*?)$/m).flatten.compact.first
       end
       cmd CMD_SHOW_VERSION
     end
@@ -221,13 +221,33 @@ module PuppetX::Force10::PossibleFacts::Base
           vlan_information[interface_location] ||= {}
           vlan_information[interface_location]['tagged_tengigabit'] ||= ""
           vlan_information[interface_location]['untagged_tengigabit'] ||= ""
+          vlan_information[interface_location]['tagged_twentyfivegigabit'] ||= ""
+          vlan_information[interface_location]['untagged_twentyfivegigabit'] ||= ""
           vlan_information[interface_location]['tagged_fortygigabit'] ||= ""
           vlan_information[interface_location]['untagged_fortygigabit'] ||= ""
+          vlan_information[interface_location]['tagged_hundredgigabit'] ||= ""
+          vlan_information[interface_location]['untagged_hundredgigabit'] ||= ""
           vlan_information[interface_location]['tagged_portchannel'] ||= ""
           vlan_information[interface_location]['untagged_portchannel'] ||= ""
 
           if interface_detail.match(/^\stagged\s+TenGigabitEthernet\s+(.*?)$/mi)
             vlan_information[interface_location]['tagged_tengigabit'] = $1
+          end
+
+          if interface_detail.match(/^\stagged\s+twentyFiveGigE\s+(.*?)$/mi)
+            vlan_information[interface_location]['tagged_twentyfivegigabit'] = $1
+          end
+
+          if interface_detail.match(/^\suntagged\s+twentyFiveGigE\s+(.*?)$/mi)
+            vlan_information[interface_location]['untagged_twentyfivegigabit'] = $1
+          end
+
+          if interface_detail.match(/^\stagged\s+hundredGigE\s+(.*?)$/mi)
+            vlan_information[interface_location]['tagged_hundredgigabit'] = $1
+          end
+
+          if interface_detail.match(/^\suntagged\s+hundredGigE\s+(.*?)$/mi)
+            vlan_information[interface_location]['untagged_hundredgigabit'] = $1
           end
 
           if interface_detail.match(/^\stagged\s+Port-channel\s+(.*?)$/mi)
@@ -258,7 +278,7 @@ module PuppetX::Force10::PossibleFacts::Base
     
 
     base.register_module_after 'system_type', 's_series', 'hardware' do
-      base.facts['system_type'].value =~ /S48*/i ||  base.facts['system_type'].value =~ /S5000/i ||  base.facts['system_type'].value =~ /S6000/i
+      base.facts['system_type'].value =~ /S48*/i ||  base.facts['system_type'].value =~ /S50*/i ||  base.facts['system_type'].value =~ /S6000/i
     end
 
     base.register_module_after 'system_type', 'm_series', 'hardware' do


### PR DESCRIPTION
Still testing, since made changes to reduce code.
Added support for twenty five and hundred gig ports.  Fixed issue with all s-series switches, where command "show interface" will no longer accept shortened port names in 9.10.  Fixed issues with version checking where Dell is now Dell EMC, that breaks either in 9.11 or 9.12.

asm-core PR: https://github.com/dell-asm/asm-core/pull/3878
asm-deployer PR:  https://github.com/dell-asm/asm-deployer/pull/2438