### PR TITLE
VXFM-5615 Removed using port-mode hybrid for no untagged vlan

### DIFF
--- a/lib/puppet/type/force10_portchannel.rb
+++ b/lib/puppet/type/force10_portchannel.rb
@@ -116,8 +116,8 @@ Puppet::Type.newtype(:force10_portchannel) do
   end
 
   def self.validate_vlan(vlan)
-    all_valid_characters = vlan =~ /^[0-9]+$/ || vlan == "NONE"
-    unless (all_valid_characters && vlan.to_i >= 1 && vlan.to_i <= 4094) || vlan == "NONE"
+    all_valid_characters = vlan =~ /^[0-9]+$/ || vlan == "none"
+    unless (all_valid_characters && vlan.to_i >= 1 && vlan.to_i <= 4094) || vlan == "none"
       raise ArgumentError, "An invalid VLAN ID #{vlan} is entered. The VLAN ID must be between 1 and 4094."
     end
   end

--- a/lib/puppet_x/force10/model/interface/base.rb
+++ b/lib/puppet_x/force10/model/interface/base.rb
@@ -461,7 +461,7 @@ module PuppetX::Force10::Model::Interface::Base
     else
       vlans_to_add = new_vlans - current_vlans
       vlans_to_add.each do |vlan|
-        next if vlan == "NONE"
+        next if vlan == "none"
         Puppet.debug("Adding vlan #{vlan} to interface #{interface_id}")
         transport.command("interface vlan #{vlan}")
 

--- a/lib/puppet_x/force10/model/portchannel/generic.rb
+++ b/lib/puppet_x/force10/model/portchannel/generic.rb
@@ -74,7 +74,7 @@ module PuppetX::Force10::Model::Portchannel::Generic
         if value == :false
           transport.command("no switchport")
         else
-          transport.command("portmode hybrid")
+          transport.command("portmode hybrid") unless base.params[:untagged_vlan].value == "none"
           transport.command("switchport")
         end
       end


### PR DESCRIPTION
Previously we vxfm used only portmode hybrid for force10. Portmode hybrid
should be removed for cases where there would online tagged vlans.