### PR TITLE
VXFM-9193 Handle long names in LLDP neighbors data

### DIFF
--- a/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
+++ b/lib/puppet_x/force10/possible_facts/hardware/m_series.rb
@@ -1,3 +1,4 @@
+require 'asm/util'
 require 'puppet_x/force10/possible_facts'
 require 'puppet_x/force10/possible_facts/hardware'
 
@@ -323,20 +324,22 @@ module PuppetX::Force10::PossibleFacts::Hardware::M_series
     end
 
     base.register_param 'remote_device_info' do
-      remote_device_info = []
-      remote_device = nil
       match do |txt|
-        txt.each_line do |line|
-          case line
-            when /^\s+(\S+\s+\d+\/\d+)\s+([^\.{3}\s]+)\s*\.{0,3}(.*)\s+(([0-9a-fA-F]{2}[:-]){5}([0-9a-fA-F]{2})).*$/
-              remote_device = { :interface => $1.strip, :location => $3.strip,:remote_mac => $4.strip,:remote_system_name => $2.strip}
-              remote_device_info <<  remote_device
-            else
-              next
-          end
+        # strip first line which contains "show lldp neighbors"
+        pos = txt.index("\n")
+        txt = txt[pos + 1, txt.length] if pos
+
+        remote_device_info = ASM::Util.parse_table(txt).map do |neighbor|
+          headers = neighbor.keys
+          { :interface => neighbor[headers[0]],
+            :location => neighbor[headers[2]],
+            :remote_mac => neighbor[headers[3]],
+            :remote_system_name => neighbor[headers[1]]}
         end
+
         remote_device_info.uniq.to_json
       end
+
       cmd CMD_SHOW_LLDP_NEIGHBORS
     end
 


### PR DESCRIPTION
In some cases the "Rem Host Name" field value is longer than the
column width. In that case it gets ellipsized and there is no space
between it and the next column:

    Loc PortID     Rem Host Name     Rem Port Id                        Rem Chassis Id
    --------------------------------------------------------------------------------
    Te 1/3         localhost.local...e4:1d:2d:bf:d7:e0                  e4:1d:2d:bf:d7:e0

This was breaking the existing parsing which was rather ad-hoc. This
change uses a helper method in dell-asm-util to parse the data safely.